### PR TITLE
fix `get_edge_ids()` issue

### DIFF
--- a/R/virgo.R
+++ b/R/virgo.R
@@ -245,7 +245,7 @@ run_solver <- function(solver, instance, sgmwcs, signals = NULL) {
     mwcs <- (if (nrow(nodes) <= 1) {
         induced_subgraph(instance, as.integer(nodes[, 1]))
     } else {
-        eids <- get.edge.ids(instance, t(edges[,1:2]))
+        eids <- get_edge_ids(instance, c(t(edges[,1:2])))
         subgraph.edges(instance, eids)
     })
     list(mwcs=mwcs, stats=stats)


### PR DESCRIPTION
igraph is changing the way `get_edge_ids()` works. (see. https://github.com/igraph/rigraph/pull/1663). In the future, the function will also accept nx2 matrices and data frames besides a vector. Currently 2xn matrices work by accident which means 2x2 matrices are hard to interpret in the transition phase (is an edge a row or a column?). This PR fixes this for the package to remove possible ambiguous cases. 